### PR TITLE
add blizko scroll and fix aui-list

### DIFF
--- a/src/blocks/blizko/list/list.css
+++ b/src/blocks/blizko/list/list.css
@@ -9,6 +9,9 @@
 .aui-list__item {
   padding: 12px;
   background-color: inherit;
+  outline: none;
+  border: 1px solid transparent;
+  box-sizing: border-box;
 }
 
 .aui-list:not(.aui-list_no-interactive) .aui-list__item:hover,

--- a/src/blocks/blizko/list/list_ordinary.css
+++ b/src/blocks/blizko/list/list_ordinary.css
@@ -8,5 +8,9 @@
 }
 
 .aui-list_ordinary .aui-list__item_selected {
-  border: 1px solid var(--orange);
+  border-color: var(--orange);
+}
+
+.aui-list_ordinary .aui-list__item_margin8:not(:last-of-type) {
+  margin-bottom: 8px;
 }

--- a/src/blocks/blizko/scroll/example/scroll.html
+++ b/src/blocks/blizko/scroll/example/scroll.html
@@ -1,0 +1,37 @@
+<div class="aui-scroll">
+  <p>Чтобы скролл заработал, необходимо повесить класс aui-scroll на контейнере, а на нужном элементе
+    указать overflow и ограничить его высоту.</p>
+  <div style="width: 50%; height: 150px; padding-right: 4px; overflow-y: auto;">
+    <ul class="aui-list aui-list_ordinary">
+      <li class="aui-list__item">Item 1</li>
+      <li class="aui-list__item">Item 2</li>
+      <li class="aui-list__item">Item 3</li>
+      <li class="aui-list__item">Item 4</li>
+      <li class="aui-list__item">Item 5</li>
+      <li class="aui-list__item aui-list__item_selected">Item 6</li>
+    </ul>
+  </div>
+</div>
+<div class="aui-scroll">
+  <p>Для переопределения цвета скролла у конкретного элемента, на нужном классе можно
+    переопределить переменную --scrollbar-color</p>
+  <style>
+    .custom {
+      --scrollbar-color: var(--orange);
+      width: 50%;
+      height: 150px;
+      padding-right: 4px;
+      overflow-y: auto;
+    }
+  </style>
+  <div class="custom">
+    <ul class="aui-list aui-list_ordinary">
+      <li class="aui-list__item">Item 1</li>
+      <li class="aui-list__item">Item 2</li>
+      <li class="aui-list__item">Item 3</li>
+      <li class="aui-list__item">Item 4</li>
+      <li class="aui-list__item">Item 5</li>
+      <li class="aui-list__item aui-list__item_selected">Item 6</li>
+    </ul>
+  </div>
+</div>

--- a/src/blocks/blizko/scroll/index.js
+++ b/src/blocks/blizko/scroll/index.js
@@ -1,0 +1,1 @@
+import './scroll.css';

--- a/src/blocks/blizko/scroll/scroll.css
+++ b/src/blocks/blizko/scroll/scroll.css
@@ -1,0 +1,18 @@
+.aui-scroll {
+  --scrollbar-color: var(--black-l90);
+}
+
+/* для FF */
+.aui-scroll * {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-color) transparent;
+}
+
+.aui-scroll *::-webkit-scrollbar {
+  width: 4px;
+}
+
+.aui-scroll *::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-color);
+  border-radius: 20%;
+}

--- a/src/blocks/blizko/select/select.css
+++ b/src/blocks/blizko/select/select.css
@@ -47,15 +47,5 @@
   border-radius: 4px;
   border: 1px solid var(--orange);
   overflow-y: auto;
-  scrollbar-width: thin; /* для FF */
   z-index: 1;
-}
-
-.aui-select_open .aui-list::-webkit-scrollbar {
-  width: 4px;
-}
-
-.aui-select_open .aui-list::-webkit-scrollbar-thumb {
-  background-color: var(--black-l90);
-  border-radius: 20%;
 }


### PR DESCRIPTION
fix: add transparent borders to .aui-list__item to prevent jumping on select and add ui-list__item_margin8 modifier
[MINOR]: Добавит скролл для Близко и модификатор ui-list__item_margin8
[PATCH]: Добавит невидимые границы к .aui-list__item чтобы избежать подпрыгивания при выборе пункта
https://jira.railsc.ru/browse/BPC-18981