### PR TITLE
fix(Pulscen): исправит стили серой кнопки и кнопки СК

### DIFF
--- a/src/blocks/pulscen/button/button_gray.css
+++ b/src/blocks/pulscen/button/button_gray.css
@@ -1,5 +1,6 @@
 .aui-button_gray,
-.aui-button_gray:link {
+.aui-button_gray:link,
+.aui-button_gray:visited {
   background: var(--medium-gray);
   color: var(--light-blue-dark);
 }

--- a/src/blocks/pulscen/cs-button-link/cs-button-link.css
+++ b/src/blocks/pulscen/cs-button-link/cs-button-link.css
@@ -3,7 +3,6 @@
   font-size: 12px;
   font-weight: 600;
   line-height: 21px;
-  color: var(--light-blue-dark);
   border: none;
   cursor: pointer;
   padding: 0 var(--indent-xs);
@@ -15,6 +14,7 @@
 .aui-cs-button-link:visited,
 .aui-cs-button-link:hover,
 .aui-cs-button-link:active {
+  color: var(--light-blue-dark);
   text-decoration: none;
   background-color: var(--medium-gray);
 }


### PR DESCRIPTION
При использовании aui-button_gray на теге \<a> не применялся серый бэкграунд.
У кнопки aui-cs-button-link по той же причине не менялся цвет текста.

https://jira.railsc.ru/browse/PC4-27125