### PR TITLE
fix: fixed Blizko radio button

### DIFF
--- a/src/blocks/blizko/radio/radio.css
+++ b/src/blocks/blizko/radio/radio.css
@@ -40,6 +40,7 @@
   background-color: var(--orange);
   opacity: 0;
   transition: .3s;
+  box-sizing: content-box;
 }
 
 .aui-radio__radio:checked + .aui-radio__label::after {


### PR DESCRIPTION
[PATCH]: Добавит свойство box-sizing: content-box для псевдоэлемента. Т.к. на некоторых страницах глобально пописано свойство box-sizing: border-box и тогда отображение ломается
https://jira.railsc.ru/browse/BPC-19285