### PR TITLE
fix: fixed Blizko input invalid border when field in focus

### DIFF
--- a/src/blocks/blizko/input/input_invalid.css
+++ b/src/blocks/blizko/input/input_invalid.css
@@ -1,4 +1,5 @@
-.aui-input_invalid .aui-input__field {
+.aui-input_invalid .aui-input__field,
+.aui-input_invalid .aui-input__field:focus {
   border-color: var(--red);
 }
 


### PR DESCRIPTION
[PATCH]: Заменит оранжевый бордер у поля с модификатором invalid на красный когда поле фокусе.
https://jira.railsc.ru/browse/BPC-19107